### PR TITLE
Add fal package

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ A curated list of awesome dbt resources
 - [dbt_audit_helper](https://github.com/dbt-labs/dbt-audit-helper/) - Macros for data audits that compare columns values and schemas between tables
 - [dbt-ml-preprocessing](https://github.com/omnata-labs/dbt-ml-preprocessing)
 - [dbt-external-tables](https://github.com/dbt-labs/dbt-external-tables)
+- [fal](https://github.com/fal-ai/fal) - run python scripts directly from your dbt project
 
 ### Visualization
 


### PR DESCRIPTION
We love dbt and we want to do more with it. Specifically we want to use it for our Data Science workloads and run python on our dbt models.

Some examples of what you can do with fal:

- download dbt models using a familiar ref
- syntax as pandas dataframes
- send slack messages on model runs
- do forecasts on metrics
- do sentiment analysis on support tickets
