### PR TITLE
Add Bruin to Orchestration section

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ Make the best out of your product quality and seamless delivery.
 
 Resources to manage and maintain dependencies in modern data pipelines.
 
+- [Bruin](https://github.com/bruin-data/bruin) - Run and schedule dbt-style SQL transformations without Airflow. Adds data ingestion (50+ sources) and built-in data quality to the transformation layer. Open-source CLI or managed [Bruin Cloud](https://getbruin.com) for teams who want dbt Cloud-like experience with ingestion included.
 - [Orchestrate dbt Core jobs with Airflow and Cosmos](https://docs.astronomer.io/learn/airflow-dbt) - Run your dbt Core projects as Apache Airflow DAGs and Task Groups.
 - [Building a Scalable Analytics Architecture with Airflow and dbt](https://www.astronomer.io/blog/airflow-dbt-1/) - Leveraging the dbt manifest in Airflow.
 - [Auto-generating an Airflow DAG using the dbt manifest](https://engineering.autotrader.co.uk/2021/09/15/auto-generated-airflow-dag-for-dbt.html) - Yet another article on extracting value from the manifest file.


### PR DESCRIPTION
## Summary
- Add [Bruin](https://github.com/bruin-data/bruin) to the Orchestration section (added at the top per LIFO guideline)

Bruin enables dbt-style SQL transformations with built-in data ingestion from 50+ sources and data quality checks. Run and schedule transformations without Airflow - open-source CLI or managed Bruin Cloud for teams who want a dbt Cloud-like experience with ingestion included.