### PR TITLE
Add Scherlok to Data Quality

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Best-practices and extensions of the testing framework.
 - [Environment-dependent Unit Testing in dbt](https://medium.com/hiflylabs/environment-dependent-unit-testing-in-dbt-c081a0a5ff1e) - Guide on how to run unit tests in dbt dynamically.
 - [dbt-expectations](https://github.com/calogica/dbt-expectations) - Port between dbt and great_expectations to extend out-of-the-box tests.
 - [re_data](https://www.getre.io/) - A dbt package for montioring metrics and detect anomalies.
+- [Scherlok](https://github.com/rbmuller/scherlok) - Zero-config data quality CLI that complements `dbt test` with auto-detected anomalies (volume, schema drift, freshness, distribution, cardinality) on every materialized model after `dbt run`.
 - [How do you test your data](https://discourse.getdbt.com/t/how-do-you-test-your-data/149) - Suggestions on testing your data powered by the community.
 - [How to unit test sql transforms in dbt](https://www.startdataengineering.com/post/how-to-test-sql-using-dbt/) - Unit test using source defer and generic custom tests.
 - [DataKitchen Open Source Data Observability](https://github.com/DataKitchen/data-observability-installer) - Data breaks. Servers break. dbt and other tools break. Observability and alerting across and down your data estate. Save time with simple, fast data quality test generation and execution. 


### PR DESCRIPTION
Adds [Scherlok](https://github.com/rbmuller/scherlok) to the **Data Quality** section, alphabetically after [re_data](https://www.getre.io/).

## What it is

Open-source CLI that complements \`dbt test\` with **auto-detected** data quality monitoring — no rules to write. Closest peers in the existing list: Elementary and re_data.

## Why it fits this list

After \`dbt run\`, Scherlok reads \`target/manifest.json\`, discovers every materialized model (table / incremental / view), auto-resolves the connection from \`profiles.yml\`, and profiles each model. It detects:

- Volume drops / spikes (z-score on row counts)
- Schema drift (added / removed / type-changed columns)
- Freshness misses (table hasn't updated in N × normal cadence)
- NULL surges, distribution shifts, cardinality changes

CI integration is one line:

\`\`\`yaml
- run: dbt run
- run: scherlok dbt --project-dir . --fail-on critical
\`\`\`

Adapter support: Postgres, BigQuery, Snowflake (via \`profiles.yml\`).

## Status

- v0.5.0 on [PyPI](https://pypi.org/project/scherlok/) — \`pip install scherlok[dbt]\`
- 207 tests, MIT licensed, no telemetry
- Active maintenance — first external PR merged within 24h of the v0.5.0 release

Happy to adjust the wording / position if you'd like a shorter description or different ordering.