### PR TITLE
Add drift to linting tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ Useful tools and extensions to bump up your analytics engineer workflow.
 - [dbtenv](https://github.com/brooklyn-data/dbtenv) - A version manager for dbt.
 - [sqlfmt](https://github.com/tconbeer/sqlfmt) - This tool formats your dbt SQL code so you don't have to.
 - [SQLFluff](https://github.com/sqlfluff/sqlfluff) - SQL linter that supports dbt and Jinja templating.
+- [drift](https://github.com/f4rkh4d/drift) - Multi-dialect SQL linter and formatter in Rust. Postgres, MySQL, SQLite, BigQuery, Snowflake. Single binary, ~448x faster than SQLFluff on plain SQL, with SARIF output for GitHub code scanning and a baseline mode for legacy adoption.
 - [Build Data Access Layer on dbt](https://github.com/coterahq/dal) - Package to build GraphQL API on top of your dbt project.
 - [Run changed models based on Git status](https://discourse.getdbt.com/t/tips-and-tricks-about-working-with-dbt/287/2) - Handy bash function to run changed models since last commit.
 - [How we set up our computers for working on dbt projects](https://discourse.getdbt.com/t/how-we-set-up-our-computers-for-working-on-dbt-projects/243) - Things I wish I would have known when started working with dbt. Tools and hacks to improve developing experience.


### PR DESCRIPTION
Adds [drift](https://github.com/f4rkh4d/drift), a multi-dialect SQL linter and formatter in Rust.

The slot in the README is right next to SQLFluff, since drift targets the same workflow (lint + format dbt-rendered SQL) but is built in Rust as a single binary.

Why it might be useful for the dbt community:

- Multi-dialect: Postgres, MySQL, SQLite, BigQuery, **Snowflake** (added in v0.16.0 specifically because dbt-snowflake teams asked first).
- Speed: median 34 ms vs SQLFluff's 15.3 s on a 200-file SQL corpus (reproducible bench in [\`benches/RESULTS.md\`](https://github.com/f4rkh4d/drift/blob/main/benches/RESULTS.md)). For dbt projects with heavy macros the multiple is smaller (60-180x) since SQLFluff's macro work pulls less from Python overhead.
- GitHub Action ready: \`uses: f4rkh4d/drift@main\`.
- SARIF output for GitHub code scanning, so violations land as inline annotations on PRs.
- Baseline mode for adopting linting on legacy SQL repos without drowning in cold-start warnings.
- Pre-commit hooks shipped at the repo root.
- Single static binary, ~2.9 MB, no Python deps in your CI image.

Released on crates.io as \`drift-sql\` (the unscoped \`drift\` was already taken). \`brew install f4rkh4d/tap/drift\` or \`cargo install drift-sql\` or the \`install.sh\` one-liner.

License: MIT.