### PR TITLE
Add ERD Studio to Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ Resources to manage and maintain dependencies in modern data pipelines.
 ## Utilities
 
 Useful tools and extensions to bump up your analytics engineer workflow.
+- [ERD Studio](https://github.com/liam-machine/erd-studio) - VS Code extension that puts a visual ERD designer inside your dbt repo. Two-stage (logical/physical) canvas, drift detection against `manifest.json`, auto-generated `selectors.yml`, and AI-readable semantic models (YAML/JSON) with a built-in harness for Claude, Copilot, Gemini, and Codex.
 - [dbtective](https://github.com/feliblo/dbtective) Rust-powered 'detective'/linter for dbt project/metadata best practices
 - [docbt](https://github.com/aleenprd/docbt) - Documentation Build Tool - Generate YAML documentation for dbt models with optional AI assistance. Built with Streamlit for an intuitive and familiar web interface.
 - [dbt-colibri]([https://github.com/godatadriven/dbt-bouncer](https://github.com/b-ned/dbt-colibri)) - Self hostable column-level lineage for dbt core projects.


### PR DESCRIPTION
Adds [ERD Studio](https://github.com/liam-machine/erd-studio) to the Utilities section (placed at the top per the LIFO convention in the README).

**What it is:** Open-source (MIT) VS Code extension that puts a visual ERD designer inside your dbt repo. The model lives as plain YAML + JSON next to the SQL — git-diffable, AI-readable, no proprietary format.

**What's distinct from existing entries:**
- Two-stage canvas: **Logical** (your design — columns, grain, SCD types, model roles, rationale) and **Physical** (derived live from `target/manifest.json`, with cardinality inferred from existing `unique` / `relationships` tests)
- **Discrepancy overlay** comparing design vs. what dbt actually built
- **Auto-generated `selectors.yml`** — one selector per ERD, so `dbt run --selector domain_silver_orders` refreshes everything in that diagram
- **AI harness** for Claude Code, GitHub Copilot, Google Gemini, and OpenAI Codex — installs the schema spec into each assistant's default config location

VS Code Marketplace: https://marketplace.visualstudio.com/items?itemName=liamwynne.erd-studio

Happy to adjust the entry phrasing if you'd prefer it shorter or in a different section.