### PR TITLE
feat: add Aegis DQ to Data Quality section

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,8 @@ Best-practices and extensions of the testing framework.
 - [How do you test your data](https://discourse.getdbt.com/t/how-do-you-test-your-data/149) - Suggestions on testing your data powered by the community.
 - [How to unit test sql transforms in dbt](https://www.startdataengineering.com/post/how-to-test-sql-using-dbt/) - Unit test using source defer and generic custom tests.
 - [DataKitchen Open Source Data Observability](https://github.com/DataKitchen/data-observability-installer) - Data breaks. Servers break. dbt and other tools break. Observability and alerting across and down your data estate. Save time with simple, fast data quality test generation and execution. 
- 
+- [Aegis DQ](https://github.com/aegis-dq/aegis-dq) - Agentic data quality framework that runs YAML rules against your warehouse (DuckDB, BigQuery, Snowflake, Databricks, Athena, Postgres), then uses LLMs to diagnose failures, trace root causes, and propose SQL fixes. Pairs naturally with dbt models as the validation layer after `dbt run`.
+
 ## CI/CD
 
 Make the best out of your product quality and seamless delivery.


### PR DESCRIPTION
## What

Adds [Aegis DQ](https://github.com/aegis-dq/aegis-dq) to the Data Quality section.

## About

Aegis DQ is an open-source (Apache 2.0) agentic data quality framework that complements dbt's testing layer. Instead of just telling you a check failed, it uses LLMs to diagnose *why*, trace the root cause, and propose a SQL fix.

**Why it fits here:**
- Runs YAML-defined rules against the same warehouses dbt targets (BigQuery, Snowflake, Databricks, Athena, Postgres, DuckDB)
- Natural post-`dbt run` validation layer — define rules against your dbt models and get LLM-powered failure analysis
- Full audit trail of every AI decision (cost, latency, prompt/response) — searchable via FTS5
- 9 MCP tools for Claude Desktop integration
- Active project: v0.7.0, Apache 2.0

**Links:**
- GitHub: https://github.com/aegis-dq/aegis-dq
- Docs: https://aegis-dq.dev
- PyPI: https://pypi.org/project/aegis-dq/