### PR TITLE
Add dbt-unirate to Packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ Useful tools and extensions to bump up your analytics engineer workflow.
 
 Community-developed packages to extend default macros and toolset.
 
+- [dbt-unirate](https://github.com/UniRate-API/dbt-unirate) - Currency exchange rate macros and models for dbt, powered by the UniRate API.
 - [dbt_semantic_view/](https://hub.getdbt.com/Snowflake-Labs/dbt_semantic_view/) This package lets you materialize Semantic Views via dbt and reference them from downstream models.
 - [dbt-ml-inline-preprocessing](https://github.com/Matts52/dbt-ml-inline-preprocessing) - Feature Engineering in dbt.
 - [dbt-snow-mask](https://github.com/entechlog/dbt-snow-mask) - A dbt package for Snowflake Dynamic Data Masking.


### PR DESCRIPTION
Adds [dbt-unirate](https://github.com/UniRate-API/dbt-unirate) to the **Packages** section (at the top, per LIFO convention).

`dbt-unirate` provides 3 Jinja macros and 2 Python models for fetching currency exchange rates into your dbt project via the UniRate API. CI matrix covers dbt 1.8 + 1.9. A [dbt Hub submission](https://github.com/dbt-labs/hubcap/pull/421) is also pending.

**Disclosure:** I maintain the UniRate API and this package.