### PR TITLE
Add backfill to Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ Resources to manage and maintain dependencies in modern data pipelines.
 ## Utilities
 
 Useful tools and extensions to bump up your analytics engineer workflow.
+- [backfill](https://github.com/shyamsivakumar/backfill) - Terminal footer that pays you while dbt runs - one sponsored line on the bottom row during long commands (dbt Core and dbt Cloud CLI), 50% ad revenue share. Open-source Go CLI; never reads your code, queries, or output.
 - [ERD Studio](https://github.com/liam-machine/erd-studio) - VS Code extension that puts a visual ERD designer inside your dbt repo. Two-stage (logical/physical) canvas, drift detection against `manifest.json`, auto-generated `selectors.yml`, and AI-readable semantic models (YAML/JSON) with a built-in harness for Claude, Copilot, Gemini, and Codex.
 - [dbtective](https://github.com/feliblo/dbtective) Rust-powered 'detective'/linter for dbt project/metadata best practices
 - [docbt](https://github.com/aleenprd/docbt) - Documentation Build Tool - Generate YAML documentation for dbt models with optional AI assistance. Built with Streamlit for an intuitive and familiar web interface.


### PR DESCRIPTION
Author here — backfill is an open-source (MIT) Go CLI that puts one clearly-labeled sponsored line on the reserved bottom row of your terminal while dbt runs, and pays the developer 50% of the ad revenue. Works with dbt Core and the dbt Cloud CLI via shell aliases; run output, summaries, and exit codes pass through untouched, and the binary never reads code/queries/output (the only telemetry is device id, ad id, command name, visible seconds — verifiable in the ~600-line source).

Added at the top of Utilities per the LIFO guideline. Happy to adjust wording or placement.