### PR TITLE
Add dbt-doctor to Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ Resources to manage and maintain dependencies in modern data pipelines.
 ## Utilities
 
 Useful tools and extensions to bump up your analytics engineer workflow.
+- [dbt-doctor](https://github.com/joachimhodana/dbt-doctor) - CLI health check and linter for dbt projects (SQL, YAML, Jinja): 190+ custom rules, optional SQLFluff, 0–100 score, GitHub Actions CI, and coding-agent skills.
 - [ERD Studio](https://github.com/liam-machine/erd-studio) - VS Code extension that puts a visual ERD designer inside your dbt repo. Two-stage (logical/physical) canvas, drift detection against `manifest.json`, auto-generated `selectors.yml`, and AI-readable semantic models (YAML/JSON) with a built-in harness for Claude, Copilot, Gemini, and Codex.
 - [dbtective](https://github.com/feliblo/dbtective) Rust-powered 'detective'/linter for dbt project/metadata best practices
 - [docbt](https://github.com/aleenprd/docbt) - Documentation Build Tool - Generate YAML documentation for dbt models with optional AI assistance. Built with Streamlit for an intuitive and familiar web interface.


### PR DESCRIPTION
## Summary

Adds [dbt-doctor](https://github.com/joachimhodana/dbt-doctor) to the **Utilities** section (LIFO, per contributing guidelines).

dbt-doctor is a CLI that scans dbt projects (model SQL, YAML, and Jinja), runs 190+ custom lint rules plus optional SQLFluff, and outputs a 0–100 health score with actionable diagnostics. It includes a GitHub Actions composite action (PR comments, annotations, fail gates) and an `install` command for coding-agent skills.

Placed alongside similar tools already listed (e.g. dbtective, dbt-score, SQLFluff).

## Test plan

- [x] Entry follows existing list format
- [x] Added at top of Utilities section per LIFO guideline