### PR TITLE
Add Misata to Data Quality

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ Use-cases and user stories implemented by the community members using components
 
 Best-practices and extensions of the testing framework.
 
+- [Misata](https://github.com/rasinmuhammed/misata) - Generate known-answer seed and test data for dbt models: declare the expected aggregates (revenue curves, rates, rollups) and assert your models return them exactly.
 - [dq-tools](https://github.com/infinitelambda/dq-tools) - Make simple storing test results and visualisation of these in a BI dashboard leveraging 6 Data Quality KPIs.
 - [BigQuery Stale data detection](https://eponkratova.medium.com/stale-data-detection-with-dbt-and-bigquery-dataset-metadata-662196cf9370) - Stale data detection with dbt and BigQuery dataset metadata.
 - [Elementary](https://github.com/elementary-data/elementary) - A dbt package that provides data anomaly detection as dbt tests.


### PR DESCRIPTION
Adds [Misata](https://github.com/rasinmuhammed/misata) to the Data Quality section.

Misata is an open-source Python companion for dbt Core. `misata dbt-seed` generates statistically realistic seeds with exact declared aggregates (revenue curves, rates, rollups) and full referential integrity, which lets you do known-answer testing: declare the expected metric, generate data that hits it, then assert your dbt model reproduces it.

Worked example with a known-answer test, verified green end to end on dbt 1.11 with dbt-duckdb (`dbt seed && dbt run && dbt test`): https://github.com/rasinmuhammed/misata/tree/main/examples/dbt

Entry added at the top of the Data Quality section per the LIFO contribution rule.