### PR TITLE
Add sqllens to Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ Resources to manage and maintain dependencies in modern data pipelines.
 ## Utilities
 
 Useful tools and extensions to bump up your analytics engineer workflow.
-- [sqllens](https://github.com/NiclasOlofsson/sqllens) - TypeScript SQL parser and analyzer that reads raw dbt models without rendering: ref/source resolution, schema diagnostics, type inference, and column-level lineage.
+- [sqllens](https://github.com/NiclasOlofsson/sqllens) - TypeScript SQL parser and static analyzer: type inference, schema diagnostics, and column-level lineage. Reads Jinja-templated SQL (dbt models) natively, without rendering.
 - [ERD Studio](https://github.com/liam-machine/erd-studio) - VS Code extension that puts a visual ERD designer inside your dbt repo. Two-stage (logical/physical) canvas, drift detection against `manifest.json`, auto-generated `selectors.yml`, and AI-readable semantic models (YAML/JSON) with a built-in harness for Claude, Copilot, Gemini, and Codex.
 - [dbtective](https://github.com/feliblo/dbtective) Rust-powered 'detective'/linter for dbt project/metadata best practices
 - [docbt](https://github.com/aleenprd/docbt) - Documentation Build Tool - Generate YAML documentation for dbt models with optional AI assistance. Built with Streamlit for an intuitive and familiar web interface.

--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ Resources to manage and maintain dependencies in modern data pipelines.
 ## Utilities
 
 Useful tools and extensions to bump up your analytics engineer workflow.
+- [sqllens](https://github.com/NiclasOlofsson/sqllens) - TypeScript SQL parser and analyzer that reads raw dbt models without rendering: ref/source resolution, schema diagnostics, type inference, and column-level lineage.
 - [ERD Studio](https://github.com/liam-machine/erd-studio) - VS Code extension that puts a visual ERD designer inside your dbt repo. Two-stage (logical/physical) canvas, drift detection against `manifest.json`, auto-generated `selectors.yml`, and AI-readable semantic models (YAML/JSON) with a built-in harness for Claude, Copilot, Gemini, and Codex.
 - [dbtective](https://github.com/feliblo/dbtective) Rust-powered 'detective'/linter for dbt project/metadata best practices
 - [docbt](https://github.com/aleenprd/docbt) - Documentation Build Tool - Generate YAML documentation for dbt models with optional AI assistance. Built with Streamlit for an intuitive and familiar web interface.


### PR DESCRIPTION
Adds sqllens, a TypeScript SQL parser and static analyzer: name resolution, type inference, schema diagnostics, and column-level lineage across the major warehouse dialects. It parses Jinja-templated SQL (dbt models) natively without rendering, so lineage and diagnostics work on the raw model text. MIT, on npm as sqllens. Disclosure: I am the author.