### PR TITLE
Add Altimate Code to Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ Resources to manage and maintain dependencies in modern data pipelines.
 ## Utilities
 
 Useful tools and extensions to bump up your analytics engineer workflow.
+- [Altimate Code](https://github.com/AltimateAI/altimate-code) - Open-source data engineering harness with 100+ deterministic tools for building, validating, optimizing, and shipping data products — usable from any LLM, across your warehouses. Ranked #1 on ADE-Bench (78%).
 - [ERD Studio](https://github.com/liam-machine/erd-studio) - VS Code extension that puts a visual ERD designer inside your dbt repo. Two-stage (logical/physical) canvas, drift detection against `manifest.json`, auto-generated `selectors.yml`, and AI-readable semantic models (YAML/JSON) with a built-in harness for Claude, Copilot, Gemini, and Codex.
 - [dbtective](https://github.com/feliblo/dbtective) Rust-powered 'detective'/linter for dbt project/metadata best practices
 - [docbt](https://github.com/aleenprd/docbt) - Documentation Build Tool - Generate YAML documentation for dbt models with optional AI assistance. Built with Streamlit for an intuitive and familiar web interface.


### PR DESCRIPTION
Adds Altimate Code, an open-source data engineering harness, to the Utilities section.

Altimate Code provides 100+ deterministic tools for building, validating, optimizing, and shipping data products, usable from any LLM, across your warehouses. Currently ranked #1 on ADE-Bench (78%).

Website: https://altimate.ai/products/altimate-code
GitHub: https://github.com/AltimateAI/altimate-code

Note: this repo already lists datapilot (https://github.com/AltimateAI/datapilot), an earlier Altimate product. Altimate Code is a separate, actively maintained tool from the same team. Happy to update or remove the datapilot line too if you'd prefer to consolidate into a single entry.