### PR TITLE
Update dbt-column-lineage URL after transfer to the Oisix org

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Useful tools and extensions to bump up your analytics engineer workflow.
 - [docbt](https://github.com/aleenprd/docbt) - Documentation Build Tool - Generate YAML documentation for dbt models with optional AI assistance. Built with Streamlit for an intuitive and familiar web interface.
 - [dbt-colibri]([https://github.com/godatadriven/dbt-bouncer](https://github.com/b-ned/dbt-colibri)) - Self hostable column-level lineage for dbt core projects.
 - [dbt-bouncer](https://github.com/godatadriven/dbt-bouncer) - Tool to configure and enforce conventions for your dbt project. 
-- [dbt-column-lineage](https://github.com/tomoki-takahashi-oisix/dbt-column-lineage) - Tool to visualize the column level lineage of dbt models.
+- [dbt-column-lineage](https://github.com/Oisix/dbt-column-lineage) - Tool to visualize the column level lineage of dbt models.
 - [metaplane cli](https://github.com/metaplane/cli) - Various tools for working with data stacks.
 - [dbt-column-lineage-extractor](https://github.com/canva-public/dbt-column-lineage-extractor) - Extract column level linage from dbt projects.
 - [tdb](https://github.com/gwenwindflower/tbd) - A sweet and speedy code generator for dbt.


### PR DESCRIPTION
Hi, thanks for maintaining this list!

`dbt-column-lineage` (my project, listed under Tools) moved from `tomoki-takahashi-oisix/dbt-column-lineage` to `Oisix/dbt-column-lineage` — it is now published as company OSS under the Oisix organization.

GitHub still redirects the old path, so the existing link is not broken, but this points the entry at the canonical location.

One-line change; the description is unchanged.