### PR TITLE
Add data-contract-validator to Data Quality

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Best-practices and extensions of the testing framework.
 - [dbt-expectations](https://github.com/calogica/dbt-expectations) - Port between dbt and great_expectations to extend out-of-the-box tests.
 - [re_data](https://www.getre.io/) - A dbt package for montioring metrics and detect anomalies.
 - [Scherlok](https://github.com/rbmuller/scherlok) - Zero-config data quality CLI that complements `dbt test` with auto-detected anomalies (volume, schema drift, freshness, distribution, cardinality) on every materialized model after `dbt run`.
+- [data-contract-validator](https://github.com/OGsiji/data-contract-validator) - Fails the pull request when a model stops producing what a downstream consumer expects. Reads columns from `catalog.json`/`manifest.json` (falling back to a sqlglot parse of the SQL) and compares them against reverse-ETL destinations such as HubSpot CRM and against FastAPI/Pydantic services, in CI or pre-commit.
 - [How do you test your data](https://discourse.getdbt.com/t/how-do-you-test-your-data/149) - Suggestions on testing your data powered by the community.
 - [How to unit test sql transforms in dbt](https://www.startdataengineering.com/post/how-to-test-sql-using-dbt/) - Unit test using source defer and generic custom tests.
 - [DataKitchen Open Source Data Observability](https://github.com/DataKitchen/data-observability-installer) - Data breaks. Servers break. dbt and other tools break. Observability and alerting across and down your data estate. Save time with simple, fast data quality test generation and execution. 


### PR DESCRIPTION
Adds [data-contract-validator](https://github.com/OGsiji/data-contract-validator) to the Data Quality section.

Most dbt testing tools check the data inside the warehouse. This one checks the boundary past it: it reads the columns a model actually produces (`catalog.json`/`manifest.json`, falling back to a sqlglot parse when those aren't available, so it also works offline in pre-commit) and compares them against what a downstream consumer expects — a reverse-ETL destination like HubSpot, or a FastAPI/Pydantic service — failing the PR when they drift apart.

The reverse-ETL case is the one I built it for: a property renamed in a CRM admin UI has no pull request and no git history, so nothing in the dbt project can see it coming.

Happy to move it to CI/CD instead if that's a better home. Disclosure: I wrote it.