### PR TITLE
Add dlin to Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ Resources to manage and maintain dependencies in modern data pipelines.
 ## Utilities
 
 Useful tools and extensions to bump up your analytics engineer workflow.
+- [dlin](https://github.com/eitsupi/dlin) - Gives coding agents instant dbt lineage: no dbt compile, no Python, no grep. Fast model-level lineage CLI parsing SQL files directly (or a `manifest.json`), with experimental column-level lineage too.
 - [Altimate Code](https://github.com/AltimateAI/altimate-code) - Open-source data engineering harness with 100+ deterministic tools for building, validating, optimizing, and shipping data products — usable from any LLM, across your warehouses. Ranked #1 on ADE-Bench (78%).
 - [ERD Studio](https://github.com/liam-machine/erd-studio) - VS Code extension that puts a visual ERD designer inside your dbt repo. Two-stage (logical/physical) canvas, drift detection against `manifest.json`, auto-generated `selectors.yml`, and AI-readable semantic models (YAML/JSON) with a built-in harness for Claude, Copilot, Gemini, and Codex.
 - [dbtective](https://github.com/feliblo/dbtective) Rust-powered 'detective'/linter for dbt project/metadata best practices


### PR DESCRIPTION
dlin is a CLI tool (written in Rust, MIT License) that provides a way for coding agents to quickly interpret dependencies between large numbers of SQL files.
It performs model-level lineage quickly without the need for `dbt compile` by directly interpreting jinja macros.

Although it has the drawback of requiring a manifest.json file after `dbt compile`, it also experimentally provides column-level lineage.